### PR TITLE
Support for message_payload parameter

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -10,6 +10,7 @@ probes:
 #    topic: internal/monitoring/mqtt-broker-ssl
 #    client_prefix: mqtt_blackbox_exporter.mqtt-broker-ssl
 #    messages: 10
+#    message_payload: "Could be any string, even with double quotes within, just \"escape the quotes\". Furthermore if you include %d it'll use the increment of the configured number of \"messages\", e.g. 0...10"
 #    interval: 30s
 
   - name: mqtt-broker-ssl

--- a/main.go
+++ b/main.go
@@ -242,13 +242,10 @@ func startProbe(probeConfig *probeConfig) {
 	msgPayload := "This is msg %d!"
 	if probeConfig.MessagePayload != "" {
 		msgPayload = probeConfig.MessagePayload
-		// logger.Printf("Using custom message payload: %s", probeConfig.MessagePayload)
 	}
 
 	for i := 0; i < num; i++ {
-		// text := fmt.Sprintf("this is msg #%d!", i)
 		text := fmt.Sprintf(msgPayload, i)
-		logger.Printf("Msg payload: %s", text)
 		token := publisher.Publish(probeConfig.Topic, qos, false, text)
 		if !token.WaitTimeout(time.Until(probeDeadline)) {
 			messagesPublishTimeout.WithLabelValues(probeConfig.Name, probeConfig.Broker).Inc()

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ type probeConfig struct {
 	InsecureSkipVerify bool          `yaml:"insecure_skip_verify"`
 	Messages           int           `yaml:"messages"`
 	TestInterval       time.Duration `yaml:"interval"`
+	MessagePayload     string        `yaml:"message_payload"`
 }
 
 var build string
@@ -237,8 +238,17 @@ func startProbe(probeConfig *probeConfig) {
 	timeout := time.After(probeTimeout)
 	receiveCount := 0
 
+	// Support for custom message payload
+	msgPayload := "This is msg %d!"
+	if probeConfig.MessagePayload != "" {
+		msgPayload = probeConfig.MessagePayload
+		// logger.Printf("Using custom message payload: %s", probeConfig.MessagePayload)
+	}
+
 	for i := 0; i < num; i++ {
-		text := fmt.Sprintf("this is msg #%d!", i)
+		// text := fmt.Sprintf("this is msg #%d!", i)
+		text := fmt.Sprintf(msgPayload, i)
+		logger.Printf("Msg payload: %s", text)
 		token := publisher.Publish(probeConfig.Topic, qos, false, text)
 		if !token.WaitTimeout(time.Until(probeDeadline)) {
 			messagesPublishTimeout.WithLabelValues(probeConfig.Name, probeConfig.Broker).Inc()


### PR DESCRIPTION
Please review my tiny PR. It adds support for the optional `message_payload` directive. It also supports to include `%d` which will increment over the number of the configured messages. Example log:

```20:16:13.495372 main.go:295: Starting mqtt_blackbox_exporter (build: )
20:16:14.289467 main.go:251: Msg payload: [{"sensor_id": "blackbox-test-hd-single", "value": "0"}]
20:16:14.289731 main.go:251: Msg payload: [{"sensor_id": "blackbox-test-hd-single", "value": "1"}]
20:16:14.289884 main.go:251: Msg payload: [{"sensor_id": "blackbox-test-hd-single", "value": "2"}]
20:16:14.290028 main.go:251: Msg payload: [{"sensor_id": "blackbox-test-hd-single", "value": "3"}]
20:16:14.290140 main.go:251: Msg payload: [{"sensor_id": "blackbox-test-hd-single", "value": "4"}]
```



I am using mqtt_blackbox_exporter to test our MQTT broker which only supports a certain type of JSON formatted payload. This led me to adding support for custom payloads myself.
I did a fair amount of testing but have to warn you, that this is my first attempt in GO and the first PR i did ever in Github ;-). Looking forward to feedback, hoping that the code is acceptable.