### PR TITLE
updated linux image and created docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:jessie
+FROM debian:bullseye
 RUN apt-get update && apt-get install -y ca-certificates
 COPY mqtt_blackbox_exporter /bin/mqtt_blackbox_exporter
 ENTRYPOINT ["/bin/mqtt_blackbox_exporter"]
-CMD ["-config.file /config.yaml"]
+CMD ["-config.file", "config.yaml", "-web.listen-address", "0.0.0.0:9214"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  mqtt_blackbox_exporter:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "9214:9214"
+    volumes:
+      - ./config.yaml:/config.yaml
+    restart: unless-stopped 


### PR DESCRIPTION
debian jessie was not updating on container creation. also added docker-compose to make it easier.

Ensure binary and config.yaml are in the folder before running docker-compose or modify paths.